### PR TITLE
Bugfix migrations error

### DIFF
--- a/db/migrate/002_create_git_lab_repositories.rb
+++ b/db/migrate/002_create_git_lab_repositories.rb
@@ -1,6 +1,7 @@
 class CreateGitLabRepositories < ActiveRecord::Migration
   def change
     create_table :git_lab_repositories do |t|
+      t.string :title
       t.string :url
       t.references :project
     end


### PR DESCRIPTION
Hi sazor,

i got a migration error with latest master. It was due to an existing migration you changed in ab10c2. Migrations once in master should never be changed afterwards.

It's a great idea to link redmine / gitlab. I always wanted something like this. 

Cheers,
simonswine
